### PR TITLE
Add RektRadar to Testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ List links and description
 ### <a name="testing"> Testing
 * [BSCheck](https://bscheck.eu/) - Free Binance Smart Chain token analyzer
 * [QuillCheck](https://check.quillai.network/) - Safeguard your web3 investments with our AI Agent. Uncover honeypots, understand token permissions, and get comprehensive market insights. Shield yourself from rugpulls and scam tokens. DYOR here!
+* [RektRadar](https://rektradar.io/) - Real-time Ethereum scam detector with mempool monitoring, deployer graph analysis, and factory pattern detection. Catches rug pulls mid-broadcast, flags honeypots before liquidity is added.
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
 * [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code


### PR DESCRIPTION
## What

Adds [RektRadar](https://rektradar.io/) to the **Testing** section, alphabetically positioned between QuillCheck and Rugscreen.

## Why

RektRadar is a free, real-time Ethereum scam detection tool that complements the existing entries (TokenSniffer, Rugscreen, QuillCheck, Rug Pull Detector) with a mempool-monitoring angle:

- Watches new pool creations across Uniswap V2/V3/V4 and flags honeypots before liquidity is added
- Maps deployer wallet history (prior rugs, funding sources, factory patterns) via on-chain graph analysis
- 36k+ tokens scanned, ~3k flagged as scams, all data publicly available

The tool is open infrastructure (14 microservices, 3 Ethereum nodes), free tier is unlimited, paid tier exists for advanced features.

## Notes

- Entry follows the same format as existing items (one-line description, no marketing fluff)
- Disclosure: I'm one of the maintainers. Happy to revise wording if it sounds too promotional.