### PR TITLE
Add Sharpe Rug Check to web3 security testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ List links and description
 * [QuillCheck](https://check.quillai.network/) - Safeguard your web3 investments with our AI Agent. Uncover honeypots, understand token permissions, and get comprehensive market insights. Shield yourself from rugpulls and scam tokens. DYOR here!
 * [RektRadar](https://rektradar.io/) - Real-time Ethereum scam detector with mempool monitoring, deployer graph analysis, and factory pattern detection. Catches rug pulls mid-broadcast, flags honeypots before liquidity is added.
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
+* [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Live token risk scanner for honeypot, liquidity, holder, ownership, and authority signals.
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
 * [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code
 ### <a name="sast"> SAST/DAST/Unity Test Analysis


### PR DESCRIPTION
## Summary
Adds Sharpe Rug Check to the Testing section.

## Fit
The Testing section already includes token and scam/rug-checking resources such as BSCheck, QuillCheck, RektRadar, Rugscreen, and TokenSniffer. Sharpe Rug Check fits that same utility-oriented group as a live token risk scanner, so the change is limited to one bullet in the existing format.

## Validation
- Website: https://www.sharpe.ai/rug-check
- Confirmed the page returns HTTP 200 on 2026-05-14.
- Checked existing open and closed PRs for Sharpe before opening this PR.

Disclosure: I'm connected with Sharpe AI.