### PR TITLE
Add SafeAgent to Other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ List links and description
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
 * [GetBlock](https://getblock.io/) - a Blockchain-as-a-Service (BaaS) platform that provides a fast and easy API connection to RPC full nodes for 50+ blockchains.
 * [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring for AI agent wallets on Solana. MCP server for verifying agent wallet identity and behavioral history before x402 micropayments — identity layer for autonomous AI agents operating in Web3. [MCP](https://intel.twzrd.xyz/mcp)
+* [SafeAgent](https://github.com/Bemosha/safeagent) - Chrome extension that detects clipboard address substitution, unlimited-approval signatures, seed-phrase input forms and typosquatted domains. Detection runs locally, no telemetry, MV3, MIT. [Chrome Web Store](https://chromewebstore.google.com/detail/ofohhhijlkclalcbfckgpinancpdapmh)
 ## <a name="bugbounty"> BugBounty
 * [Hacken Proof](https://hackenproof.com/) - Expert web3 bug bounty and crowdsourced audit platform
 * [Immunefi](https://immunefi.com/) - Web3's bug bounty platform


### PR DESCRIPTION
Adds SafeAgent under Tools > Other tools.

Chrome extension (MV3, TypeScript, MIT) with four local detectors:

- Clipboard address substitution — compares the copied address against the buffer for 60s (ETH, BTC, TRX, SOL). The user copies an address, malware replaces it in the buffer, and the pasted address is the attacker's — a step transaction simulators don't cover.
- Approval signatures — inspects approve / setApprovalForAll / permit and EIP-712 typed data before the request reaches the wallet
- Seed-phrase input forms — DOM scan for 12/24-word layouts
- Phishing domains — blacklist plus Levenshtein typosquatting check

Detection is local. No accounts, no telemetry, no remote code (strict CSP).

Repo: https://github.com/Bemosha/safeagent
Published by https://holder.io

Happy to move it to a different section if that fits better.